### PR TITLE
fix: prevent double HTML escaping in attribute interpolation

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -3,7 +3,6 @@ package vuego
 import (
 	"bytes"
 	"fmt"
-	"html"
 	"regexp"
 	"strings"
 )
@@ -31,7 +30,7 @@ func (v *VueGo) interpolateText(input string) string {
 		val, ok := v.scope.Resolve(expr)
 		if ok && val != nil {
 			// Escape value for HTML output
-			out.WriteString(html.EscapeString(fmt.Sprint(val)))
+			out.WriteString(fmt.Sprint(val))
 		} else {
 			out.WriteString("")
 		}

--- a/vuego_test.go
+++ b/vuego_test.go
@@ -1,0 +1,25 @@
+package vuego
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDoubleEscapingBug(t *testing.T) {
+	const template = `<div data-tooltip="{{value}}"></div>`
+
+	var out bytes.Buffer
+	err := Render(&out, template, map[string]any{
+		"value": "A & B",
+	})
+
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	result := out.String()
+	expected := `<div data-tooltip="A &amp; B"></div>`
+	if result != expected {
+		t.Errorf("Double escaping detected!\nExpected: %s\nGot:      %s", expected, result)
+	}
+}


### PR DESCRIPTION
## Problem

Discovered a CRITICAL bug causing double HTML escaping when using `{{}}` interpolation in HTML attributes.

### What was happening:
1. User provides data: `{"value": "A & B"}`
2. Template: `<div data-tooltip="{{value}}"></div>`
3. **Bug**: Output was `<div data-tooltip="A &amp;amp; B"></div>` 
4. **Expected**: Output should be `<div data-tooltip="A &amp; B"></div>` 

### Root Cause:
The `interpolateText()` function was calling `html.EscapeString()` on interpolated values. Then, the attribute rendering code in `renderElementSkippingVFor()` was escaping the same value again, resulting in double-escaping.
```go
// interpolate.go (line 33) - FIRST escape
out.WriteString(html.EscapeString(fmt.Sprint(val)))

// vuego.go (line 176) - SECOND escape
escaped := html.EscapeString(a.Val)
```

## Solution

Removed HTML escaping from `interpolateText()`. Now escaping happens only once at the final output stage:
- For attributes: escaped when rendering the attribute (vuego.go line 176)
- For text nodes: escaped when writing text content (vuego.go line 99)

## Testing

Added test case `TestDoubleEscapingBug` that verifies:
- Input: `"A & B"`
- Output: `"A &amp; B"` (correctly escaped once)
- NOT: `"A &amp;amp; B"` (incorrectly double-escaped)

## Impact

- Fixes incorrect rendering of special HTML characters in attributes
- No breaking changes to existing functionality
- Text node interpolation still works correctly (escaping at write time)
- Attribute binding (`:attr` and `v-bind:`) unaffected